### PR TITLE
feat: remove newlines from docker auth base64

### DIFF
--- a/configs/build-and-push-container.yaml
+++ b/configs/build-and-push-container.yaml
@@ -8,5 +8,5 @@
  script:
    - echo "Building and pushing the image to $CI_REGISTRY_IMAGE"
    - mkdir -p /kaniko/.docker
-   - echo "{\"auths\":{\"$CI_REGISTRY\":{\"auth\":\"$(echo -n $CI_REGISTRY_USER:$CI_REGISTRY_PASSWORD | base64)\"}}}" > /kaniko/.docker/config.json
+   - echo "{\"auths\":{\"$CI_REGISTRY\":{\"auth\":\"$(echo -n $CI_REGISTRY_USER:$CI_REGISTRY_PASSWORD | base64 | tr -d '\n')\"}}}" > /kaniko/.docker/config.json
    - /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --destination $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME $ADDLATESTTAG $FORMATTEDTAGLIST $IMAGE_LABELS --label build-date=`date -Iseconds`


### PR DESCRIPTION
before this, it was possible to reach the 70
char limit of base64, after which it adds a
newline. This newline then breaks docker auth.

Another way would be to use the `-w 0` base64 flag, but the base64 in the kaniko container does not support that